### PR TITLE
Display actual command key used instead of a fixed string

### DIFF
--- a/amx.el
+++ b/amx.el
@@ -219,10 +219,6 @@ Enabling this feature can cause a noticeable delay when running
 nil) if you don't find it useful."
   :type 'boolean)
 
-(defcustom amx-prompt-string "M-x "
-  "String to display in the Amx prompt."
-  :type 'string)
-
 (defcustom amx-ignored-command-matchers
   '("self-insert-command"
     "\\`self-insert-and-exit\\'"
@@ -454,7 +450,9 @@ minibuffer.."
 (defun amx-prompt-with-prefix-arg ()
   "Return `amx-prompt-string' with the prefix arg prepended."
   (let ((amx-prompt-string
-         (or amx-temp-prompt-string amx-prompt-string)))
+         (or amx-temp-prompt-string
+	     (format "%s "
+		     (format-kbd-macro (this-single-command-keys))))))
     (setq amx-temp-prompt-string nil)
     (if (not current-prefix-arg)
         amx-prompt-string

--- a/tests/test-amx.el
+++ b/tests/test-amx.el
@@ -95,7 +95,6 @@ equal."
        amx-save-file
        amx-history-length
        amx-show-key-bindings
-       amx-prompt-string
        amx-ignored-command-matchers
        amx-backend
        smex-save-file))
@@ -112,7 +111,6 @@ equal."
        amx-save-file
        amx-history-length
        amx-show-key-bindings
-       amx-prompt-string
        amx-ignored-command-matchers
        amx-backend
        smex-save-file)))
@@ -133,18 +131,6 @@ equal."
     (expect
      (customize-set-variable 'amx-backend 'ivy)
      :to-throw))
-
-  (it "should use the prompt string specified in `amx-prompt-string'"
-    (customize-set-variable 'amx-prompt-string "Run command: ")
-    (let (observed-prompt)
-      (expect
-       (with-simulated-input
-           '((setq observed-prompt (buffer-substring (point-min) (point)))
-             "ignore RET")
-         (amx-completing-read '("ignore")))
-       :to-equal "ignore")
-      (expect observed-prompt
-              :to-match amx-prompt-string)))
 
   (it "should activate `amx-map' while running amx"
 


### PR DESCRIPTION
Remove the fixed string ("M-x") and display the actual command used. This means it works even if you bind it to something else and also displayed the right things for M-X bound to `amx-major-mode-commands`.

I don't know how to simulate the key press to test the prompt in the test so I've removed that test.