### PR TITLE
Typo fixes

### DIFF
--- a/amx.el
+++ b/amx.el
@@ -67,7 +67,7 @@ This should be set to a function that accepts a symbol
 representing the name of a command.")
 
 (defvar amx-minibuffer-depth -1
-  "Used to determin if amx \"owns\" the current active minibuffer.")
+  "Used to determine if amx \"owns\" the current active minibuffer.")
 
 (defvar amx-command-keybind-hash (make-hash-table :size 0)
   "Hash table for translating between commands and key bindings.
@@ -433,7 +433,7 @@ This must be run from `ido-setup-hook'."
 
 This should work for most completion backends, without having to
 know exactly which functions each one uses to exit the
-minibuffer.."
+minibuffer."
   (execute-kbd-macro (kbd "RET")))
 
 (cl-defun amx-completing-read (choices &key initial-input predicate def backend)


### PR DESCRIPTION
I ran flyspell on the rest of the buffer and didn't see any other misspellings.