### PR TITLE
Allow for amx to use fuzzy match when using Helm backend.

### DIFF
--- a/amx.el
+++ b/amx.el
@@ -626,7 +626,8 @@ May not work for things like ido and ivy."
                   :buffer "Helm M-x Completions"
                   :history extended-command-history
                   :reverse-history t
-                  :must-match t
+                  :must-match nil
+		  :fuzzy t
                   :keymap (make-composed-keymap amx-map helm-comp-read-map)))
 
 (amx-define-backend


### PR DESCRIPTION
Hey there,

I made a small modification to my amx setup using helm backend to support fuzzy matching and I thought it would be worth sharing the idea.

One problem that I see is that, although fuzzy matching is more convenient, not all users use it. In this case there should be an user option for turning on/off. Because the backend set up in neat way I found kind of awkward to write such option in there, but in principle we can fetch for ``helm-completion-styles`` to see if ``helm-fuzzy`` is enabled or for ``emacs`` and see if ``completion-style`` has ``flex`` or ``helm-flex``.