### PR TITLE
Update selectrum backend

### DIFF
--- a/amx.el
+++ b/amx.el
@@ -755,6 +755,7 @@ By default, an appropriate method is selected based on whether
           (const :tag "Ido" ido)
           (const :tag "Ivy" ivy)
           (const :tag "Helm" helm)
+          (const :tag "Selectrum" selectrum)
           (const :tag "Standard" standard)
           (symbol :tag "Custom backend"))
   :set #'amx-set-backend)

--- a/amx.el
+++ b/amx.el
@@ -652,18 +652,18 @@ May not work for things like ido and ivy."
   (minibuffer-with-setup-hook
       (lambda ()
         (setq-local selectrum-should-sort nil)
-        ;; FIXME: This should be removed after it can be assumed all amx users
-        ;; updated also Selectrum.
-        (setq-local selectrum-should-sort-p nil)
         (use-local-map (make-composed-keymap
                         (list amx-map (current-local-map)))))
-    (selectrum-completing-read (amx-prompt-with-prefix-arg)
-                               choices
-                               predicate
-                               t
-                               initial-input
-                               'extended-command-history
-                               def)))
+    ;; FIXME: `selectrum-should-sort-p' should be removed after it can be
+    ;; assumed all amx users updated also Selectrum.
+    (let ((selectrum-should-sort-p nil))
+      (selectrum-completing-read (amx-prompt-with-prefix-arg)
+                                 choices
+                                 predicate
+                                 t
+                                 initial-input
+                                 'extended-command-history
+                                 def))))
 
 (amx-define-backend
  :name 'selectrum

--- a/amx.el
+++ b/amx.el
@@ -643,34 +643,28 @@ May not work for things like ido and ivy."
  :required-feature 'helm
  :auto-activate '(bound-and-true-p helm-mode))
 
-(declare-function selectrum-read "ext:selectrum")
-(declare-function selectrum--normalize-collection "ext:selectrum")
-(defvar selectrum-should-sort-p)
-(defvar selectrum--previous-input-string)
+(declare-function selectrum-completing-read "ext:selectrum")
+(defvar selectrum-should-sort)
 
 (cl-defun amx-completing-read-selectrum (choices &key initial-input predicate def)
   "Amx backend for selectrum completion."
-  (let ((choices (cl-remove-if-not (or predicate #'identity)
-                                   choices))
-        (selectrum-should-sort-p nil))
-    (minibuffer-with-setup-hook
-        (lambda ()
-          (use-local-map (make-composed-keymap
-                          (list amx-map (current-local-map)))))
-      (selectrum-read (amx-prompt-with-prefix-arg)
-                      (selectrum--normalize-collection choices)
-                      :history 'extended-command-history
-                      :require-match t
-                      :default-candidate def
-                      :initial-input initial-input))))
-
-(defun amx-selectrum-get-text ()
-  selectrum--previous-input-string)
+  (minibuffer-with-setup-hook
+      (lambda ()
+        (setq-local selectrum-should-sort nil)
+        (use-local-map (make-composed-keymap
+                        (list amx-map (current-local-map)))))
+    (selectrum-completing-read (amx-prompt-with-prefix-arg)
+                               choices
+                               predicate
+                               t
+                               initial-input
+                               'extended-command-history
+                               def)))
 
 (amx-define-backend
  :name 'selectrum
  :comp-fun 'amx-completing-read-selectrum
- :get-text-fun 'amx-selectrum-get-text
+ :get-text-fun 'amx-default-get-text
  :required-feature 'selectrum
  :auto-activate '(bound-and-true-p selectrum-mode))
 

--- a/amx.el
+++ b/amx.el
@@ -645,12 +645,14 @@ May not work for things like ido and ivy."
 
 (declare-function selectrum-completing-read "ext:selectrum")
 (defvar selectrum-should-sort)
+(defvar selectrum-should-sort-p)
 
 (cl-defun amx-completing-read-selectrum (choices &key initial-input predicate def)
   "Amx backend for selectrum completion."
   (minibuffer-with-setup-hook
       (lambda ()
         (setq-local selectrum-should-sort nil)
+        (setq-local selectrum-should-sort-p nil)
         (use-local-map (make-composed-keymap
                         (list amx-map (current-local-map)))))
     (selectrum-completing-read (amx-prompt-with-prefix-arg)

--- a/amx.el
+++ b/amx.el
@@ -652,6 +652,8 @@ May not work for things like ido and ivy."
   (minibuffer-with-setup-hook
       (lambda ()
         (setq-local selectrum-should-sort nil)
+        ;; FIXME: This should be removed after it can be assumed all amx users
+        ;; updated also Selectrum.
         (setq-local selectrum-should-sort-p nil)
         (use-local-map (make-composed-keymap
                         (list amx-map (current-local-map)))))

--- a/tests/test-amx.el
+++ b/tests/test-amx.el
@@ -304,12 +304,12 @@ equal."
             (expect (featurep 'selectrum)))
 
           (it "should call `selectrum-read'"
-            (spy-on 'selectrum-read :and-call-through)
+            (spy-on 'selectrum-completing-read :and-call-through)
             (expect
              (with-simulated-input "ignore RET"
                (amx-completing-read '("ignore")))
              :to-equal "ignore")
-            (expect 'selectrum-read
+            (expect 'selectrum-completing-read
                     :to-have-been-called))
           (it "should properly exit the minibuffer with custom actions"
             (spy-on 'where-is)
@@ -317,11 +317,11 @@ equal."
               (amx-read-and-run '("ignore")))
             (expect 'where-is :to-have-been-called-with 'ignore))
           (it "should properly update and rerun"
-            (spy-on 'amx-selectrum-get-text :and-call-through)
+            (spy-on 'amx-default-get-text :and-call-through)
             (let ((enable-recursive-minibuffers t))
               (with-simulated-input '("ig" (amx-update-and-rerun) "nore RET")
                 (amx-read-and-run '("ignore"))))
-            (expect 'amx-selectrum-get-text :to-have-been-called)))
+            (expect 'amx-default-get-text :to-have-been-called)))
       (xit "is not available for testing")))
 
   (describe "auto backend"
@@ -347,7 +347,7 @@ equal."
             (selectrum-mode 0)
             (cl-loop
              for fun in
-             '(completing-read-default ido-completing-read+ ivy-read helm-comp-read selectrum-read)
+             '(completing-read-default ido-completing-read+ ivy-read helm-comp-read selectrum-completing-read)
              do (spy-on fun :and-return-value "ignore")))
 
           ;; Restore the saved value after each test
@@ -380,7 +380,7 @@ equal."
           (it "should use selectrum completion when `selectrum-mode' is enabled"
             (selectrum-mode 1)
             (amx-completing-read '("ignore"))
-            (expect 'selectrum-read
+            (expect 'selectrum-completing-read
                     :to-have-been-called)))
       (xit "is not available for testing")))
 


### PR DESCRIPTION
The API of Selectrum has changed (see https://github.com/raxod502/selectrum/pull/446) this PR updates the Selectrum backend accordingly. There is also no need to rely on any private functions/variables anymore.