### PR TITLE
Do not offer nonexistent commands for completion

### DIFF
--- a/amx.el
+++ b/amx.el
@@ -771,10 +771,10 @@ This should be the name of backend defined using
   ;; This speeds up sorting.
   (let (new-commands)
     (mapatoms (lambda (symbol)
-                (let ((known-command (assq symbol amx-data)))
-                  (if known-command
-                      (setq amx-cache (cons known-command amx-cache))
-                    (when (commandp symbol)
+                (when (commandp symbol)
+                  (let ((known-command (assq symbol amx-data)))
+                    (if known-command
+                        (setq amx-cache (cons known-command amx-cache))
                       (setq new-commands (cons (list symbol) new-commands)))))))
     (if (eq (length amx-cache) 0)
         (setq amx-cache new-commands)


### PR DESCRIPTION
In amx-rebuild-cache, check commandp before adding symbols from amx-data to amx-cache.  Previously, any symbol present in amx-data (the saved history) was added to the completion cache unconditionally, even if that symbol was no longer defined as a command in the current session (e.g. because the command was deleted, renamed, or its defining package was not loaded).  This caused amx completion to suggest non-existent commands.

The fix moves the commandp check to gate both branches: known commands from amx-data and newly discovered commands.  Symbols that are in amx-data but do not currently satisfy commandp are left in amx-data (preserving history for commands that may be loaded later) but excluded from amx-cache (the completion list).

Fix #52